### PR TITLE
Fix syntax errors in auth, NSC, and utility modules

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -1,5 +1,5 @@
 import { supabase } from './supabaseClient.js';
-import { state, setUser } from './state.js';
+import { state, setUser, subscribe } from './state.js';
 import { renderAuthBox, modal } from './components.js';
 
 
@@ -67,4 +67,14 @@ const root = modal(`
 </div>
 `);
 root.querySelector('#reg-cancel').onclick = ()=> root.innerHTML='';
+  root.querySelector('#reg-create').onclick = async ()=>{
+    const email = document.getElementById('reg-email').value.trim();
+    const pass = document.getElementById('reg-pass').value;
+    const { data, error } = await supabase.auth.signUp({ email, password: pass });
+    if (error){ alert(error.message); return; }
+    setUser(data.user);
+    root.innerHTML='';
+  };
+}
+
 subscribe(mountAuthBox);

--- a/js/nscs.js
+++ b/js/nscs.js
@@ -82,4 +82,16 @@ tbody.innerHTML = filtered.map(row).join('');
 
 // Sortier-Header
 document.querySelectorAll('th[data-sf]').forEach(th=>{
+  th.addEventListener('click', ()=>{
+    const sf = th.getAttribute('data-sf');
+    if (sortField === sf){
+      sortDir *= -1;
+    } else {
+      sortField = sf;
+      sortDir = 1;
+    }
+    const sorted = sortItems(items.slice());
+    tbody.innerHTML = sorted.map(row).join('');
+  });
+});
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -3,77 +3,74 @@ export const AV_MONTHS = [
 'Praios','Rondra','Efferd','Travia','Boron','Hesinde','Firun','Tsa','Phex','Peraine','Ingerimm','Rahja'
 ];
 
-
 // Epochale Zuordnung zu ISO (für FullCalendar/Timeline rein technisch)
 const ISO_EPOCH = '2000-01-01'; // beliebig, nur konsistent
 
-
 function pad(n){ return String(n).padStart(2,'0'); }
 
-
 export function formatAvDate({year, month, day}){
-const m = AV_MONTHS[month-1] || `Monat ${month}`;
-return `${day}. ${m} ${year} BF`;
+  const m = AV_MONTHS[month-1] || `Monat ${month}`;
+  return `${day}. ${m} ${year} BF`;
 }
-
 
 // Umrechnungen: Aventurisch <-> fortlaufender Tag (ab 1 Praios 0 BF)
 export function avToDayNumber({year, month, day}){
-const y = Number(year), m = Number(month), d = Number(day);
-return y * 360 + (m-1) * 30 + (d-1); // 360 Tage/Jahr
+  const y = Number(year), m = Number(month), d = Number(day);
+  return y * 360 + (m-1) * 30 + (d-1); // 360 Tage/Jahr
 }
 export function dayNumberToAv(num){
-const year = Math.floor(num/360);
-const rem = num % 360;
-const month = Math.floor(rem/30)+1;
-const day = (rem % 30)+1;
-return { year, month, day };
+  const year = Math.floor(num/360);
+  const rem = num % 360;
+  const month = Math.floor(rem/30)+1;
+  const day = (rem % 30)+1;
+  return { year, month, day };
 }
-
 
 // ISO Datum nur für Visualisierung (Epoch + Tage)
 export function avToISO(av){
-const n = avToDayNumber(av);
-const base = new Date(ISO_EPOCH);
-base.setDate(base.getDate() + n);
-const y = base.getUTCFullYear();
-const m = pad(base.getUTCMonth()+1);
-const d = pad(base.getUTCDate());
-return `${y}-${m}-${d}`;
+  const n = avToDayNumber(av);
+  const base = new Date(ISO_EPOCH);
+  base.setDate(base.getDate() + n);
+  const y = base.getUTCFullYear();
+  const m = pad(base.getUTCMonth()+1);
+  const d = pad(base.getUTCDate());
+  return `${y}-${m}-${d}`;
 }
 export function isoToAv(iso){
-const base = new Date(ISO_EPOCH);
-const cur = new Date(iso);
-const diffDays = Math.round((cur - base)/86400000);
-return dayNumberToAv(diffDays);
+  const base = new Date(ISO_EPOCH);
+  const cur = new Date(iso);
+  const diffDays = Math.round((cur - base)/86400000);
+  return dayNumberToAv(diffDays);
 }
-
 
 export function datePickerAv(idPrefix, value){
-const y = value?.year ?? 1027;
-const m = value?.month ?? 1;
-const d = value?.day ?? 1;
-return `
-<div class="row">
-<div>
-<div class="label">Tag</div>
-<input class="input" id="${idPrefix}-day" type="number" min="1" max="30" value="${d}">
-</div>
-<div>
-<div class="label">Monat</div>
-<select class="input" id="${idPrefix}-month">
-${AV_MONTHS.map((nm, idx)=>`<option value="${idx+1}" ${idx+1===Number(m)?'selected':''}>${nm}</option>`).join('')}
-</select>
-</div>
-</div>
-<div>
-<div class="label">Jahr (BF)</div>
-<input class="input" id="${idPrefix}-year" type="number" value="${y}">
-</div>`;
+  const y = value?.year ?? 1027;
+  const m = value?.month ?? 1;
+  const d = value?.day ?? 1;
+  return `
+  <div class="row">
+  <div>
+  <div class="label">Tag</div>
+  <input class="input" id="${idPrefix}-day" type="number" min="1" max="30" value="${d}">
+  </div>
+  <div>
+  <div class="label">Monat</div>
+  <select class="input" id="${idPrefix}-month">
+  ${AV_MONTHS.map((nm, idx)=>`<option value="${idx+1}" ${idx+1===Number(m)?'selected':''}>${nm}</option>`).join('')}
+  </select>
+  </div>
+  </div>
+  <div>
+  <div class="label">Jahr (BF)</div>
+  <input class="input" id="${idPrefix}-year" type="number" value="${y}">
+  </div>`;
 }
 export function readDatePickerAv(idPrefix){
-return {
-day: Number(document.getElementById(`${idPrefix}-day`).value),
-month: Number(document.getElementById(`${idPrefix}-month`).value),
-year: Number(document.getElementById(`${idPrefix}-year`).value)
+  return {
+    day: Number(document.getElementById(`${idPrefix}-day`).value),
+    month: Number(document.getElementById(`${idPrefix}-month`).value),
+    year: Number(document.getElementById(`${idPrefix}-year`).value)
+  };
+}
+
 export function uid(){ return Math.random().toString(36).slice(2); }


### PR DESCRIPTION
## Summary
- complete auth registration logic and subscribe to state changes
- implement NSC table sorting logic
- finalize date picker utility and uid helper

## Testing
- `node --check js/auth.js`
- `node --check js/nscs.js`
- `node --check js/utils.js`


------
https://chatgpt.com/codex/tasks/task_e_68b9412caeec83229261711fab00ad85